### PR TITLE
feat: stop function for http server and automatic port listen

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ const schema = new Schema({
   enablePlayground: true,
 });
 
-const server = HTTPServerHelper.create({
+HTTPServerHelper.create({
+  port: 3000,
   schema,
   path: '/tws',
 });
-
-server.listen(3000);
 ```
 
 Send a request to the server:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tws-js/server",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tws-js/server",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@tws-js/common": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.1",
+  "version": "2.1.0",
   "name": "@tws-js/server",
   "description": "Type-Safe Web Server Framework",
   "license": "MIT",

--- a/test/unit/httpServerHelper.spec.ts
+++ b/test/unit/httpServerHelper.spec.ts
@@ -347,7 +347,12 @@ describe('Server', () => {
       enableSchema: true,
     };
 
+    const fakeServer = {
+      on: jest.fn().mockImplementation((_, cb) => cb()),
+    };
+
     const fakeExpress = {
+      listen: jest.fn().mockReturnValue(fakeServer),
       post: jest.fn(),
       get: jest.fn(),
       options: jest.fn(),
@@ -376,7 +381,8 @@ describe('Server', () => {
 
     const logger = { error: jest.fn() };
 
-    const server = HTTPServerHelper.create({
+    const server = await HTTPServerHelper.create({
+      port: 2345,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       schema,
@@ -390,7 +396,10 @@ describe('Server', () => {
       schemaPath: '/schema',
     });
 
-    expect(server).toBe(fakeExpress);
+    expect(server.url).toBe('http://localhost:2345');
+    expect(server.app).toBe(fakeExpress);
+    expect(server.server).toBe(fakeServer);
+    expect(server.stop).toBeInstanceOf(Function);
 
     expect(fakeExpress.post).toHaveBeenCalledWith('/path', fakeListener);
     expect(fakeExpress.get).toHaveBeenCalledTimes(2);
@@ -398,6 +407,7 @@ describe('Server', () => {
     expect(fakeExpress.get).toHaveBeenNthCalledWith(2, '/schema', fakeListenerSchema);
     expect(fakeExpress.options).toHaveBeenCalledTimes(1);
     expect(fakeExpress.options).toHaveBeenNthCalledWith(1, '*', fakeListenerOptions);
+    expect(fakeExpress.listen).toHaveBeenCalledWith(2345);
 
     expect(HTTPServerHelper.createExpressServerListener).toHaveBeenCalledWith({
       schema,
@@ -439,7 +449,12 @@ describe('Server', () => {
       enableSchema: true,
     };
 
+    const fakeServer = {
+      on: jest.fn().mockImplementation((_, cb) => cb()),
+    };
+
     const fakeExpress = {
+      listen: jest.fn().mockReturnValue(fakeServer),
       post: jest.fn(),
       get: jest.fn(),
       options: jest.fn(),
@@ -468,7 +483,8 @@ describe('Server', () => {
 
     const logger = { error: jest.fn() };
 
-    const server = HTTPServerHelper.create({
+    const server = await HTTPServerHelper.create({
+      port: 2345,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       schema,
@@ -476,7 +492,10 @@ describe('Server', () => {
       enablePlayground: true,
     });
 
-    expect(server).toBe(fakeExpress);
+    expect(server.url).toBe('http://localhost:2345');
+    expect(server.app).toBe(fakeExpress);
+    expect(server.server).toBe(fakeServer);
+    expect(server.stop).toBeInstanceOf(Function);
 
     expect(fakeExpress.post).toHaveBeenCalledWith('/tws', fakeListener);
     expect(fakeExpress.get).toHaveBeenCalledTimes(2);
@@ -484,6 +503,8 @@ describe('Server', () => {
     expect(fakeExpress.get).toHaveBeenNthCalledWith(2, '/tws/schema', fakeListenerSchema);
     expect(fakeExpress.options).toHaveBeenCalledTimes(1);
     expect(fakeExpress.options).toHaveBeenNthCalledWith(1, '*', fakeListenerOptions);
+    expect(fakeExpress.listen).toHaveBeenCalledWith(2345);
+    expect(fakeServer.on).toHaveBeenCalledWith('listening', expect.any(Function));
 
     expect(HTTPServerHelper.createExpressServerListener).toHaveBeenCalledWith({
       schema,


### PR DESCRIPTION
## Description

This PR makes small adjustments to the helper function that creates an HTTP Server, by listening to a port automatically and returning an object with a helper function to stop the server

## Changes
- Listen to port as soon as the HTTP Server is created
- Return object containing informations about the HTTP server along with a stop function
- Simplified e2e helper functions to create an HTTP Server